### PR TITLE
Osf Exercise Seven

### DIFF
--- a/force-app/main/default/classes/DataTableColumn.cls
+++ b/force-app/main/default/classes/DataTableColumn.cls
@@ -1,0 +1,19 @@
+public class DataTableColumn {
+    
+@AuraEnabled
+public String label {get;set;}
+@AuraEnabled
+public String fieldName {get;set;}
+@AuraEnabled
+public String type {get;set;}
+@AuraEnabled
+public Boolean sortable {get;set;}
+
+    
+    public DataTableColumn(String label) {
+        this.label = label;
+        this.fieldName = label;
+        this.type = 'text';
+        this.sortable = true;
+    }
+}

--- a/force-app/main/default/classes/DataTableColumn.cls-meta.xml
+++ b/force-app/main/default/classes/DataTableColumn.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>50.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/DataTableRecords.cls
+++ b/force-app/main/default/classes/DataTableRecords.cls
@@ -1,0 +1,31 @@
+public with sharing class DataTableRecords{
+    @AuraEnabled(cacheable=true)
+    public static List<sObject> getDataTableRecordsView(String objectAPIDataTable, String fieldsAPI){
+
+        String query = '';
+        if(!String.isEmpty(fieldsAPI)){
+            query = 'SELECT Name, Id, CreatedDate, ' + fieldsAPI + ' FROM ' + objectAPIDataTable + ' ORDER BY CreatedDate ASC LIMIT 25';
+        }
+        else{
+            query = 'SELECT Name, Id, CreatedDate, FROM ' + objectAPIDataTable + ' ORDER BY CreatedDate ASC LIMIT 25';
+        }
+         
+        return Database.query(query);
+    }
+
+    @AuraEnabled(cacheable=true)
+    public static List<DataTableColumn> getDataTableColumns(String fieldsAPI){
+
+        //Static columns
+        String allFields = 'Name,Id,CreatedDate';
+        List<DataTableColumn> columns = new List<DataTableColumn>();
+        if(!String.isEmpty(fieldsAPI)) {
+            allFields += ',' +  fieldsAPI;       
+        }
+        for(String column : allFields.split(',')){
+            columns.add(new DataTableColumn(column));
+        }
+
+        return columns;
+    }
+}

--- a/force-app/main/default/classes/DataTableRecords.cls-meta.xml
+++ b/force-app/main/default/classes/DataTableRecords.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>50.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/TreeViewRecords.cls
+++ b/force-app/main/default/classes/TreeViewRecords.cls
@@ -6,25 +6,25 @@ public with sharing class TreeViewRecords {
         String[] fields;
         
         if(!String.isEmpty(fieldsAPI)) {
-            query = 'SELECT Name, Id, CreatedDate, ' + fieldsAPI + ' FROM ' + objectAPITreeView + ' ORDER BY CreatedDate ASC LIMIT 25';
+            query = 'SELECT Name, Id, CreatedDate, ' + String.escapeSingleQuotes(fieldsAPI) + ' FROM ' +  + ' ORDER BY CreatedDate ASC LIMIT 25';
             fields = fieldsAPI.split(',');
         }
         else {
-            query = 'SELECT Name, Id, CreatedDate FROM ' + objectAPITreeView + ' ORDER BY CreatedDate ASC LIMIT 25';
+            query = 'SELECT Name, Id, CreatedDate FROM ' + String.escapeSingleQuotes(objectAPITreeView) + ' ORDER BY CreatedDate ASC LIMIT 25';
         }
 
         Integer countName = 0;
         List<sObject> sObjList =  Database.query(query);
 		List<TreeViewWrapper> rootList = new List<TreeViewWrapper>();
         
-        if(sObjList.size() > 0){
+        if(!sObjList.isEmpty()){
             for(Integer i=0; i < sObjList.size(); i++) {
                 List<TreeViewWrapper> childWrapper = new List<TreeViewWrapper>();                
 				TreeViewWrapper wrapperRoot = new TreeViewWrapper(sObjList[i].get('Name').toString(), String.valueOf(++countName), false, childWrapper);
                 childWrapper.add(new TreeViewWrapper(sObjList[i].get('Name').toString(), String.valueOf(++countName), false, new List<TreeViewWrapper>()));
                 childWrapper.add(new TreeViewWrapper(sObjList[i].get('Id').toString(), String.valueOf(++countName), false, new List<TreeViewWrapper>()));
                 childWrapper.add(new TreeViewWrapper(sObjList[i].get('CreatedDate').toString(), String.valueOf(++countName), false, new List<TreeViewWrapper>()));
-                if(fields.size() > 0){
+                if(fields.isEmpty()){
                     for(String field : fields) {
                         childWrapper.add(new TreeViewWrapper(sObjList[i].get(field.trim()).toString(),String.valueOf(++countName), false, new List<TreeViewWrapper>()));
                     }

--- a/force-app/main/default/classes/TreeViewRecords.cls
+++ b/force-app/main/default/classes/TreeViewRecords.cls
@@ -1,0 +1,37 @@
+public with sharing class TreeViewRecords {
+    @AuraEnabled(cacheable=true)
+    public static List<TreeViewWrapper> getRecordsTreeView(String objectAPITreeView, String fieldsAPI){
+        
+        String query = '';
+        String[] fields;
+        
+        if(!String.isEmpty(fieldsAPI)) {
+            query = 'SELECT Name, Id, CreatedDate, ' + fieldsAPI + ' FROM ' + objectAPITreeView + ' ORDER BY CreatedDate ASC LIMIT 25';
+            fields = fieldsAPI.split(',');
+        }
+        else {
+            query = 'SELECT Name, Id, CreatedDate FROM ' + objectAPITreeView + ' ORDER BY CreatedDate ASC LIMIT 25';
+        }
+
+        Integer countName = 0;
+        List<sObject> sObjList =  Database.query(query);
+		List<TreeViewWrapper> rootList = new List<TreeViewWrapper>();
+        
+        if(sObjList.size() > 0){
+            for(Integer i=0; i < sObjList.size(); i++) {
+                List<TreeViewWrapper> childWrapper = new List<TreeViewWrapper>();                
+				TreeViewWrapper wrapperRoot = new TreeViewWrapper(sObjList[i].get('Name').toString(), String.valueOf(++countName), false, childWrapper);
+                childWrapper.add(new TreeViewWrapper(sObjList[i].get('Name').toString(), String.valueOf(++countName), false, new List<TreeViewWrapper>()));
+                childWrapper.add(new TreeViewWrapper(sObjList[i].get('Id').toString(), String.valueOf(++countName), false, new List<TreeViewWrapper>()));
+                childWrapper.add(new TreeViewWrapper(sObjList[i].get('CreatedDate').toString(), String.valueOf(++countName), false, new List<TreeViewWrapper>()));
+                if(fields.size() > 0){
+                    for(String field : fields) {
+                        childWrapper.add(new TreeViewWrapper(sObjList[i].get(field.trim()).toString(),String.valueOf(++countName), false, new List<TreeViewWrapper>()));
+                    }
+                }               
+                rootList.add(wrapperRoot);
+        	}
+        }        
+        return rootList;
+    }
+}

--- a/force-app/main/default/classes/TreeViewRecords.cls-meta.xml
+++ b/force-app/main/default/classes/TreeViewRecords.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>50.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/TreeViewWrapper.cls
+++ b/force-app/main/default/classes/TreeViewWrapper.cls
@@ -1,4 +1,4 @@
-public class TreeViewWrapper {  
+public with sharing class TreeViewWrapper {  
 	@AuraEnabled
     public String label;
     @AuraEnabled

--- a/force-app/main/default/classes/TreeViewWrapper.cls
+++ b/force-app/main/default/classes/TreeViewWrapper.cls
@@ -1,0 +1,17 @@
+public class TreeViewWrapper {  
+	@AuraEnabled
+    public String label;
+    @AuraEnabled
+	public String name;
+    @AuraEnabled 
+    public Boolean expanded;
+    @AuraEnabled
+    public List<TreeViewWrapper> items;
+    
+    public TreeViewWrapper(String label, String name, Boolean expanded, List<TreeViewWrapper> items){
+        this.label = label;
+        this.name = name;
+        this.expanded = expanded;
+        this.items = items;
+    }
+}

--- a/force-app/main/default/classes/TreeViewWrapper.cls-meta.xml
+++ b/force-app/main/default/classes/TreeViewWrapper.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>51.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/lwc/inputExSeven/inputExSeven.css
+++ b/force-app/main/default/lwc/inputExSeven/inputExSeven.css
@@ -1,0 +1,3 @@
+.lgc-bg {
+    background-color: #FFF;
+}

--- a/force-app/main/default/lwc/inputExSeven/inputExSeven.html
+++ b/force-app/main/default/lwc/inputExSeven/inputExSeven.html
@@ -1,0 +1,18 @@
+<template>
+    <lightning-card>
+        <lightning-input type="text" onchange={handleObjectAPITextChange} label="Object API name"></lightning-input>
+        <lightning-input type="text" onchange={handleObjectAPIFieldChange} label="Field API names"></lightning-input>
+        <lightning-button variant="brand" label="Submit" title="Submit" onclick={handleClick} class="slds-m-left_x-small"></lightning-button>
+    </lightning-card>
+    <div class="lgc-bg">
+        <lightning-tabset>
+            <lightning-tab label="Tree">                
+                <lightning-tree items={treeItems}></lightning-tree>                
+            </lightning-tab>
+            <lightning-tab label="Table">
+                <lightning-datatable data={dataTableItems} columns={columns} key-field="Id" hide-checkbox-column="true">
+                </lightning-datatable> 
+            </lightning-tab>
+        </lightning-tabset>
+    </div>
+</template>

--- a/force-app/main/default/lwc/inputExSeven/inputExSeven.js
+++ b/force-app/main/default/lwc/inputExSeven/inputExSeven.js
@@ -1,0 +1,85 @@
+import { LightningElement, track, api, wire } from 'lwc';
+import getRecordsTreeView from '@salesforce/apex/TreeViewRecords.getRecordsTreeView'
+import getDataTableRecordsView from '@salesforce/apex/DatatableRecords.getDataTableRecordsView'
+import getDataTableColumn from '@salesforce/apex/DatatableRecords.getDataTableColumns'
+import { ShowToastEvent } from 'lightning/platformShowToastEvent';
+
+export default class InputExSeven extends LightningElement {
+    @track treeItems;
+    @track error;
+    @track dataTableItems;
+    @track objectAPI;
+    @track fieldsAPI;
+    @track columns = [{
+        label: 'Name',
+        fieldName: 'Name',
+        type: 'text',
+        sortable: true
+    },
+    {
+        label: 'Id',
+        fieldName: 'Id',
+        type: 'text',
+        sortable: true
+    },
+    {
+        label: 'Created Date',
+        fieldName: 'CreatedDate',
+        type: 'date',
+        sortable: true
+    }
+]; 
+
+    handleObjectAPITextChange(event){
+        this.objectAPI = event.target.value;
+    }
+
+    handleObjectAPIFieldChange(event){
+        this.fieldsAPI = event.target.value;
+    }
+
+    handleClick() {
+
+        getDataTableColumn({ fieldsAPI: this.fieldsAPI })
+        .then(result =>{
+            this.columns = JSON.stringify(result);
+        })
+        .catch(error => {
+            this.dispatchEvent(
+                new ShowToastEvent({
+                    title: 'Error on retrieving from Datatable Columns',
+                    message: error.body.message,
+                    variant: 'error'
+                })
+            );
+        });
+
+        getDataTableRecordsView({ objectAPIDataTable: this.objectAPI, fieldsAPI: this.fieldsAPI })
+        .then(result =>{
+            this.dataTableItems = result;
+        })
+        .catch(error => {
+            this.dispatchEvent(
+                new ShowToastEvent({
+                    title: 'Error on retrieving from Datatable',
+                    message: error.body.message,
+                    variant: 'error'
+                })
+            );
+        });
+
+        getRecordsTreeView({ objectAPITreeView: this.objectAPI, fieldsAPI: this.fieldsAPI })
+        .then(result =>{
+            this.treeItems = result;
+        })
+        .catch(error => {
+            this.dispatchEvent(
+                new ShowToastEvent({
+                    title: 'Error on retrieving from TreeView',
+                    message: error.body.message,
+                    variant: 'error'
+                })
+            );
+        });
+    }
+}

--- a/force-app/main/default/lwc/inputExSeven/inputExSeven.js-meta.xml
+++ b/force-app/main/default/lwc/inputExSeven/inputExSeven.js-meta.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>50.0</apiVersion>
+    <isExposed>true</isExposed>
+    <targets>
+        <target>lightning__AppPage</target>
+        <target>lightning__RecordPage</target>
+        <target>lightning__HomePage</target>
+    </targets>
+</LightningComponentBundle>


### PR DESCRIPTION
Use Case: 

Some users in an organization need to have read-only access to 25 oldest records of any type in organization


Objective:

Default fields for these records are (order remains)

Name
CreatedDate
Id
Data is ordered by CreatedDate field ascendent

In order to meet this requirement developer decided to implement Lightning Component (LC) that utilizes query editor functionality in the next manner

2 text inputs

Object API name (Accepts 1 object type only)
Field API names (comma-separated list)
Submit button

The results pane displays a tabset

Tree view:
Name:
Name
CreatedDate
Id
the rest of the fields
Data-table view:
Name  |  CreatedDate  |  Id  |  the rest of the fields
Implementation should handle incorrect object and field names

All data should be displayed as a plain text

Consider the use of standard lightning components